### PR TITLE
Fixed BiStim bug, re-added setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,4 +132,8 @@ dmypy.json
 pyvenv.cfg
 pip-selfcheck.json
 
+### macOS invisible files ###
+.DS_Store
+.DS_STORE
+
 # End of https://www.gitignore.io/api/python

--- a/magpy/magstim.py
+++ b/magpy/magstim.py
@@ -502,7 +502,7 @@ class Magstim(object):
                 return Magstim.PARAMETER_ACQUISTION_ERR
             else:
                 # Switch keys depending on whether we're returning for a BiStim
-                if self.__class__ == 'BiStim':
+                if type(self).__name__ == 'BiStim':
                     priorPower = priorPower['bistimParam']['powerA'] if _commandByte == b'@' else priorPower['bistimParam']['powerB']
                 else:
                     priorPower = priorPower['magstimParam']['power']
@@ -1197,7 +1197,7 @@ class Rapid(Magstim):
                 if not currentParameters['rapid']['singlePulseMode']:
                     maxFrequency = Rapid.MAX_FREQUENCY[self._voltage][self._super][currentParameters['rapidParam']['power']]
                     if currentParameters['rapidParam']['frequency'] > maxFrequency:
-                        if not self.setFreqeuncy(maxFrequency)[0]:
+                        if not self.setFrequency(maxFrequency)[0]:
                             return Magstim.PARAMETER_UPDATE_ERR
             else:
                 return Magstim.PARAMETER_ACQUISTION_ERR

--- a/magpy/magstim.py
+++ b/magpy/magstim.py
@@ -502,7 +502,7 @@ class Magstim(object):
                 return Magstim.PARAMETER_ACQUISTION_ERR
             else:
                 # Switch keys depending on whether we're returning for a BiStim
-                if type(self).__name__ == 'BiStim':
+                if isinstance(self, BiStim):
                     priorPower = priorPower['bistimParam']['powerA'] if _commandByte == b'@' else priorPower['bistimParam']['powerB']
                 else:
                     priorPower = priorPower['magstimParam']['power']

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+
+from setuptools import setup
+
+
+install_packages = ['magpy']
+
+setup(
+	name='MagPy',
+	version='1.2.0b1',
+	description='A Python toolbox for controlling Magstim TMS stimulators via serial communication',
+	author='Nicolas McNair',
+	author_email='nicolas.mcnair@sydney.edu.au',
+	url='http://github.com/nicolasmcnair/magpy',
+	packages=['magpy'],
+	python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*',
+	install_requires=['PySerial']
+
+)

--- a/setup.py
+++ b/setup.py
@@ -2,18 +2,21 @@
 
 from setuptools import setup
 
-
-install_packages = ['magpy']
-
 setup(
-	name='MagPy',
-	version='1.2.0b1',
-	description='A Python toolbox for controlling Magstim TMS stimulators via serial communication',
-	author='Nicolas McNair',
-	author_email='nicolas.mcnair@sydney.edu.au',
-	url='http://github.com/nicolasmcnair/magpy',
-	packages=['magpy'],
-	python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*',
-	install_requires=['PySerial']
-
+    name='MagPy_TMS',
+    version='1.2.0b8',
+    description='A Python toolbox for controlling Magstim TMS stimulators via serial communication',
+    long_description='A Python toolbox for controlling Magstim TMS stimulators via serial communication',
+    author='Nicolas McNair',
+    author_email='nicolas.mcnair@sydney.edu.au',
+    url='http://github.com/nicolasmcnair/magpy',
+    classifiers=['Development Status :: 4 - Beta',
+                 'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+                 'Programming Language :: Python :: 2.7',
+                 'Programming Language :: Python :: 3'],
+    keywords='TMS Magstim',
+    packages=['magpy'],
+    package_data={'magpy':['*.yaml']},
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*',
+    install_requires=['pyserial']
 )


### PR DESCRIPTION
While debugging an experiment today, I ran into & fixed a bug with setting power levels on a BiStim: it crashes setting power if you set `delay` to True, because the line that checks if the MagStim class is 'BiStim' doesn't work right and always returns "False" . With the below fix, everything works as intended. Additionally, pylint caught a small typo in a function name so I fixed that too (if you don't currently use pylint I highly recommend it, it's great for catching small errors like that and it integrates really nicely with Visual Studio Code).

I re-added the project's setup.py file as well so the latest version can always be installed directly from GitHub using pip. If it was removed intentionally, I can revise the pull request to leave it out.

Thanks again for maintaining this project!